### PR TITLE
Changed the log line format to comply with bGeigieMini standard.

### DIFF
--- a/bGeigieNano.ino
+++ b/bGeigieNano.ino
@@ -876,7 +876,7 @@ bool gps_gen_timestamp(TinyGPS &gps, char *buf, unsigned long counts, unsigned l
 
   // prepare the log entry
   memset(buf, 0, LINE_SZ);
-  sprintf_P(buf, PSTR("$%s,%04d,%02d-%02d-%02dT%02d:%02d:%02dZ,%ld,%ld,%ld,%c,%s,%c,%s,%c,%s,%c,%d,%ld"),  \
+  sprintf_P(buf, PSTR("$%s,%04d,%02d-%02d-%02dT%02d:%02d:%02dZ,%ld,%ld,%ld,%c,%s,%c,%s,%c,%s,%c,%ld,"),  \
               NANO_HEADER, \
               config.device_id, \
               year, month, day,  \
@@ -889,7 +889,6 @@ bool gps_gen_timestamp(TinyGPS &gps, char *buf, unsigned long counts, unsigned l
               lon, WE,\
               strbuffer, \
               gps_status, \
-              nbsat  == TinyGPS::GPS_INVALID_SATELLITES ? 0 : nbsat, \
               precission == TinyGPS::GPS_INVALID_HDOP ? 0 : precission);
 
   len = strlen(buf);


### PR DESCRIPTION
I recently noticed that the [safecastapi](https://github.com/Safecast/safecastapi/blob/master/app/models/bgeigie_import.rb#L153) database is built on the structure of a bGeigieMini log line structure.

I have modified the bGeigieNano log line format to comply to this structure in order not to introduce inconsistent data in the DB.

The difference is small. Only the two last fields of the line are affected:

bGeigieMini: HDOP,FixQuality
bGeigieNano: NBSat,HDOP

Since the bGeigieNano uses the TinyGPS library that do not provide the fix quality field, I have moved back HDOP by one position and left the FixQuality field empty.

new bGeigieNano: HDOP,
